### PR TITLE
fix: renamed postinstall script for iOS to avoid running in linux/windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Download and install all necessary packages:
 
 Install pods:
 
-    npm postinstall
+    npm podinstall
 
 Start the server:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
         "": {
             "name": "mobile-techtest",
             "version": "0.0.1",
-            "hasInstallScript": true,
             "dependencies": {
                 "react": "18.0.0",
                 "react-native": "0.69.4"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "private": true,
     "scripts": {
         "start": "react-native start",
-        "postinstall": "cd ios/ && pod install && cd ..",
+        "podinstall": "cd ios/ && pod install && cd ..",
         "android": "react-native run-android",
         "ios": "react-native run-ios",
         "lint": "eslint .",


### PR DESCRIPTION
We have `postInstall` script mentioned in `package.json`, which is by definition meant for `iOS` pods install, but it's not always the case since if someone running `npm install` on `Linux`/ `windows` machine would run into following issue mentioned in the screenshot.
![image](https://user-images.githubusercontent.com/20874455/202586649-1afeed8f-4b66-459b-94df-b06666a40abf.png)

The reason for that npm follows the order to run the `pre` and `post` script for every command run in the terminal like this `npm word`, which means the order of script call will be like this `npm preword` , `npm word`, `npm postword`. more about this can be found [here](https://docs.npmjs.com/cli/v9/using-npm/scripts#pre--post-scripts) in the npm doc.

To avoid this conflict, this PR aims to rename the pod install script from post-install so that it won't run in Linux machine unncessarily